### PR TITLE
[SM-1110] - Fix `undefined` error for `field`

### DIFF
--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -264,7 +264,7 @@ class LookupModule(LookupBase):
         secret_id = terms[0]
         self.validate_secret_id(secret_id)
 
-        field = kwargs.get("field") or "value"
+        field = self.get_option("field") or "value"
         self.validate_field(field)
 
         base_url = self.get_option("base_url")


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1110

## 🚧 Type of change

-   🐛 Bug fix

## 📔 Objective

The `field` option was being retrieved with `kargs.get`, which causes an `undefined` error to be thrown from Jinja2 when it parses the input parameters. This updates `field` to use the provided `get_option` with the rest of the input parameters, which fixes this issue.

## 📋 Code changes

-   **`plugins/lookup/lookup.py`:** Use the provided `get_option` from `AnsiblePlugin` on `field`. This was missed when [updating the other input parameters](https://github.com/bitwarden/sm-ansible/pull/8/commits/49b284ab734dacc9f7c79090f9e0795a3fdffe23).

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
    issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
