### PR TITLE
Fix string interpolation error on failure to lookup secret by access token

### DIFF
--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -371,6 +371,6 @@ class LookupModule(LookupBase):
             secret_data: str = secret.to_dict()["data"][field]
             return [secret_data]
         except Exception as e:
-            error_message = f"{SECRET_LOOKUP_ERROR.format(secret_id)}: {e}"
+            error_message = SECRET_LOOKUP_ERROR.format(secret_id, e)
             display.error(error_message)
             raise AnsibleLookupError(error_message) from e


### PR DESCRIPTION
This fixes a positional error with string interpolation here, causing IndexErrors. Introduced from previous refactoring in [this commit](https://github.com/bitwarden/sm-ansible/commit/601df6c1cb8ce26e47a62b419888796671c2cdda). Pretty simple fix, encountered this while deploying an ansible playbook. The stack trace is revealed when running ansible with -vvv and pretty clearly shows the issue (replacing PII with 'SECRET' here):

exception during Jinja2 execution: Traceback (most recent call last):
  File "/home/SECRET/.ansible/collections/ansible_collections/bitwarden/secrets/plugins/lookup/lookup.py", line 370, in get_secret_data
    secret: SecretResponse = client.secrets().get(secret_id)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/SECRET/.local/lib/python3.12/site-packages/bitwarden_sdk/bitwarden_client.py", line 41, in get
    result = self.client._run_command(
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/SECRET/.local/lib/python3.12/site-packages/bitwarden_sdk/bitwarden_client.py", line 32, in _run_command
    raise Exception(response["errorMessage"])
Exception: Received error message from server: [404 Not Found] {"message":"Resource not found.","validationErrors":null,"exceptionMessage":null,"exceptionStackTrace":null,"innerExceptionMessage":null,"object":"error"}

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/ansible/template/__init__.py", line 873, in _lookup
    ran = instance.run(loop_terms, variables=self._available_variables, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/SECRET/.ansible/collections/ansible_collections/bitwarden/secrets/plugins/lookup/lookup.py", line 288, in run
    return self.get_secret_data(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/SECRET/.ansible/collections/ansible_collections/bitwarden/secrets/plugins/lookup/lookup.py", line 374, in get_secret_data
    error_message = f"{SECRET_LOOKUP_ERROR.format(secret_id)}: {e}"
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
IndexError: Replacement index 1 out of range for positional args tuple
fatal: [localhost]: FAILED! => {
    "msg": "An unhandled exception occurred while templating '{'SECRET': {'SECRET': \"{{ lookup('bitwarden.secrets.lookup', 'SECRET') }}\"}}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while running the lookup plugin 'bitwarden.secrets.lookup'. Error was a <class 'IndexError'>, original message: Replacement index 1 out of range for positional args tuple. Replacement index 1 out of range for positional args tuple"
}



## 🎟️ Tracking

Created this drive by fix to help y'all out, not actually sure how you track this

## 🚧 Type of change

-   🐛 Bug fix

## 📔 Objective

So my error messages are far less confusing and not obfuscated by unrelated IndexErrors 

## 📋 Code changes

-   **lookup.py:** Bug is here

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
    issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
