### PR TITLE
[SM-1247] - fix non-default API/Identity URLs being ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ __pycache__
 
 # Vagrant
 .vagrant/
+
+# Ansible Galaxy artifacts
+bitwarden-secrets-*.tar.gz

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -316,9 +316,7 @@ class LookupModule(LookupBase):
             identity_url = f"{base_url}/identity"
             return (api_url, identity_url)
         else:
-            if api_url == BITWARDEN_API_URL and identity_url == BITWARDEN_IDENTITY_URL:
-                return (api_url, identity_url)
-            elif (
+            if (
                 api_url != BITWARDEN_API_URL and identity_url == BITWARDEN_IDENTITY_URL
             ) or (
                 api_url == BITWARDEN_API_URL and identity_url != BITWARDEN_IDENTITY_URL

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -270,6 +270,7 @@ class LookupModule(LookupBase):
         base_url = self.get_option("base_url")
         api_url = self.get_option("api_url")
         identity_url = self.get_option("identity_url")
+        base_url, api_url, identity_url = self.sanitize_urls(base_url, api_url, identity_url)
         api_url, identity_url = self.get_urls(base_url, api_url, identity_url)
         self.validate_urls(api_url, identity_url)
 
@@ -293,6 +294,15 @@ class LookupModule(LookupBase):
             identity_url,
             state_file_dir,
         )
+
+    @staticmethod
+    def sanitize_urls(*args):
+        sanitized_inputs = []
+        for input_var in args:
+            input_var = str(input_var).strip()
+            input_var = input_var.rstrip("/")
+            sanitized_inputs.append(input_var)
+        return sanitized_inputs
 
     @staticmethod
     def get_urls(base_url: str, api_url: str, identity_url: str) -> tuple[str, str]:

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -308,27 +308,26 @@ class LookupModule(LookupBase):
         return sanitized_inputs
 
     @staticmethod
-    def get_urls(base_url: str, api_url: str, identity_url: str) -> tuple[str, str]:
-        if api_url == BITWARDEN_API_URL and identity_url != BITWARDEN_IDENTITY_URL:
-            # unset the default API URL so that the error message is correct.
-            # otherwise, the user will see the default API URL in the error message,
-            # which is confusing
-            api_url = None
-            display.error(API_IDENTITY_URL_ERROR.format(api_url, identity_url))
-            raise AnsibleError(API_IDENTITY_URL_ERROR.format(api_url, identity_url))
-        elif api_url != BITWARDEN_API_URL and identity_url == BITWARDEN_IDENTITY_URL:
-            # unset the default Identity URL so that the error message is correct.
-            # otherwise, the user will see the default Identity URL in the error message,
-            # which is confusing
-            identity_url = None
-            display.error(API_IDENTITY_URL_ERROR.format(api_url, identity_url))
-            raise AnsibleError(API_IDENTITY_URL_ERROR.format(api_url, identity_url))
-        elif base_url != BITWARDEN_BASE_URL:
+    def get_urls(
+        base_url: str = None, api_url: str = None, identity_url: str = None
+    ) -> tuple[str, str]:
+        if base_url != BITWARDEN_BASE_URL:
             api_url = f"{base_url}/api"
             identity_url = f"{base_url}/identity"
-            return api_url, identity_url
+            return (api_url, identity_url)
         else:
-            return api_url, identity_url
+            if api_url == BITWARDEN_API_URL and identity_url == BITWARDEN_IDENTITY_URL:
+                return (api_url, identity_url)
+            elif (
+                api_url != BITWARDEN_API_URL and identity_url == BITWARDEN_IDENTITY_URL
+            ) or (
+                api_url == BITWARDEN_API_URL and identity_url != BITWARDEN_IDENTITY_URL
+            ):
+                raise AnsibleError(API_IDENTITY_URL_ERROR.format(api_url, identity_url))
+            return (
+                api_url,
+                identity_url,
+            )
 
     @staticmethod
     def validate_urls(api_url, identity_url) -> None:

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -271,7 +271,9 @@ class LookupModule(LookupBase):
         base_url = self.get_option("base_url")
         api_url = self.get_option("api_url")
         identity_url = self.get_option("identity_url")
-        base_url, api_url, identity_url = self.sanitize_urls(base_url, api_url, identity_url)
+        base_url, api_url, identity_url = self.sanitize_urls(
+            base_url, api_url, identity_url
+        )
         api_url, identity_url = self.get_urls(base_url, api_url, identity_url)
         self.validate_urls(api_url, identity_url)
 

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -323,6 +323,11 @@ class LookupModule(LookupBase):
             ) or (
                 api_url == BITWARDEN_API_URL and identity_url != BITWARDEN_IDENTITY_URL
             ):
+                # unset the default URLs before throwing the error
+                if api_url == BITWARDEN_API_URL:
+                    api_url = None
+                if identity_url == BITWARDEN_IDENTITY_URL:
+                    identity_url = None
                 raise AnsibleError(API_IDENTITY_URL_ERROR.format(api_url, identity_url))
             return (
                 api_url,

--- a/tests/unit/validation_tests.py
+++ b/tests/unit/validation_tests.py
@@ -81,12 +81,6 @@ class TestValidators(unittest.TestCase):
         self.assertEqual(api_url, f"{self.base_url}/api")
         self.assertEqual(identity_url, f"{self.base_url}/identity")
 
-    def test_get_urls_default_urls(self):
-        """if no urls are provided, use defaults"""
-        api_url, identity_url = LookupModule.get_urls(None, None, None)
-        self.assertEqual(api_url, BITWARDEN_API_URL)
-        self.assertEqual(identity_url, BITWARDEN_IDENTITY_URL)
-
     def test_get_urls_base_url_provided_ignores_api_url_identity_url(self):
         """if base_url is provided, api_url and identity_url are ignored"""
         api_url, identity_url = LookupModule.get_urls(

--- a/tests/unit/validation_tests.py
+++ b/tests/unit/validation_tests.py
@@ -6,6 +6,7 @@ from plugins.lookup.lookup import (
     AnsibleError,
     LookupModule,
     validate_url,
+    BITWARDEN_BASE_URL,
     BITWARDEN_API_URL,
     BITWARDEN_IDENTITY_URL,
 )
@@ -69,14 +70,16 @@ class TestValidators(unittest.TestCase):
     # get_urls tests
     def test_get_urls_base_url(self):
         """if base_url is provided, derive api_url and identity_url from it"""
-        api_url, identity_url = LookupModule.get_urls(self.base_url, None, None)
+        api_url, identity_url = LookupModule.get_urls(
+            self.base_url, BITWARDEN_API_URL, BITWARDEN_IDENTITY_URL
+        )
         self.assertEqual(api_url, f"{self.base_url}/api")
         self.assertEqual(identity_url, f"{self.base_url}/identity")
 
     def test_get_urls_api_url_identity_url(self):
         """if api_url and identity_url are provided, use them"""
         api_url, identity_url = LookupModule.get_urls(
-            None, self.api_url, self.identity_url
+            BITWARDEN_BASE_URL, self.api_url, self.identity_url
         )
         self.assertEqual(api_url, f"{self.base_url}/api")
         self.assertEqual(identity_url, f"{self.base_url}/identity")
@@ -91,12 +94,22 @@ class TestValidators(unittest.TestCase):
 
     def test_get_urls_api_url_provided_but_identity_url_not_throws(self):
         """if api_url is provided but identity_url is not, raise AnsibleError"""
-        self.assertRaises(AnsibleError, LookupModule.get_urls, None, self.api_url, None)
+        self.assertRaises(
+            AnsibleError,
+            LookupModule.get_urls,
+            BITWARDEN_BASE_URL,
+            self.api_url,
+            BITWARDEN_IDENTITY_URL,
+        )
 
     def test_get_urls_identity_url_provided_but_api_url_not_throws(self):
         """if identity_url is provided but api_url is not, raise AnsibleError"""
         self.assertRaises(
-            AnsibleError, LookupModule.get_urls, None, None, self.identity_url
+            AnsibleError,
+            LookupModule.get_urls,
+            BITWARDEN_BASE_URL,
+            BITWARDEN_API_URL,
+            self.identity_url,
         )
 
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1247

## 🚧 Type of change

-   🐛 Bug fix

## 📔 Objective

Previously, if a user provided `api_url` and `identity_url` in their playbook, they would be ignored and would instead default to `https://api.bitwarden.com` and `https://identity.bitwarden.com`, respectively. This PR fixes that bug.

## 📋 Code changes

-   **plugins/lookup/lookup.py:** fix faulty logic in the `get_urls` function, where we derive the api and identity urls that get passed to `BitwardenClient`. The cases where we look for `None` values for were never triggered because Ansible's `get_option` always sets the input parameters to the defaults that were provided in the Ansible doc strings. `get_urls` was updated to check for the _default_ values, instead of `None` for the urls. Also, added a function to strip whitespace and forward-slashes from urls.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
    issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
