### PR TITLE
Use newer Python binding for authentication

### DIFF
--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -219,10 +219,10 @@ class AccessToken:
             self._encryption_key = base64.b64decode(encryption_key)
         except ValueError:
             display.error(
-                "Invalid access token envryption key. Should be base64-encoded"
+                "Invalid access token encryption key. Should be base64-encoded"
             )
             raise AccessTokenInvalidError(
-                "Invalid access token envryption key. Should be base64-encoded"
+                "Invalid access token encryption key. Should be base64-encoded"
             )
 
         if len(self._encryption_key) != 16:

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -161,12 +161,13 @@ def validate_url(url: str, url_type: str) -> None:
         raise AnsibleError(INVALID_URL_ERROR.format(url_type, url))
 
 
-def create_state_dir(state_file_dir: str):
+def create_state_dir(state_file_dir: str) -> Path:
     try:
         state_file_dir = os.path.expanduser(state_file_dir)
         display.vv(f"Creating state directory: {state_file_dir}")
         state_dir = Path(state_file_dir)
         state_dir.mkdir(parents=True, exist_ok=True)
+        return state_dir
     except PermissionError:
         raise AnsibleError(
             f"You do not have permission to create a directory at {state_file_dir}"
@@ -378,8 +379,9 @@ class LookupModule(LookupBase):
         )
 
         try:
-            create_state_dir(state_file_dir)
-            state_file = str(Path(state_file_dir, access_token.access_token_id).expanduser())
+            state_dir = create_state_dir(state_file_dir)
+            state_file = str(state_dir / access_token.access_token_id)
+            display.vv(f"state_file: {state_file}")
             client.access_token_login(access_token.str, state_file)
         except AnsibleError as e:
             display.error(STATE_FILE_DIR_ERROR.format(e, state_file_dir))

--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -382,7 +382,7 @@ class LookupModule(LookupBase):
             state_dir = create_state_dir(state_file_dir)
             state_file = str(state_dir / access_token.access_token_id)
             display.vv(f"state_file: {state_file}")
-            client.access_token_login(access_token.str, state_file)
+            client.auth().login_access_token(access_token.str, state_file)
         except AnsibleError as e:
             display.error(STATE_FILE_DIR_ERROR.format(e, state_file_dir))
             raise AnsibleError(STATE_FILE_DIR_ERROR.format(e, state_file_dir)) from e


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SM-1416

## 🚧 Type of change

-   🧹 Tech debt (refactoring, code cleanup, dependency upgrades, etc.)

## 📔 Objective

Update the Ansible lookup plugin to work with the upcoming changes to the Python SDK in https://github.com/bitwarden/sdk/pull/964.

## 📋 Code changes

-   **plugins/lookup/lookup.py:** Use the newer `auth().login_access_token` method from upcoming Python SDK changes. We can't force any particular version of the Python SDK, so instead we'll display a warning that advises the user to update to the latest `bitwarden-sdk` if they're using the older `access_token_login` method.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed
    issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
