### PR TITLE
fix: parse access token (#86)

### DIFF
--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -205,8 +205,8 @@ class AccessToken:
             display.error("No access token provided")
             raise AccessTokenInvalidError("No access token provided")
         try:
-            first_part, encryption_key = self._access_token.split(":")
-            version, access_token_id, client_secret = first_part.split(".")
+            _, encryption_key = self._access_token.split(":")
+            version, access_token_id, client_secret = encryption_key.lstrip().split(".")
         except ValueError:
             display.error("Invalid access token format")
             raise AccessTokenInvalidError("Invalid access token format")


### PR DESCRIPTION
## 🎟️ Tracking

https://github.com/bitwarden/sm-ansible/issues/86

## 🚧 Type of change

-   🐛 Bug fix

## 📔 Objective

Allow to use an access key.

## 📋 Code changes

Parse the encryption key instead of the bearer prefix

-   **file.ext:** Description of what was changed and why.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Protected functional changes with optionality (feature flags)
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines
