### PR TITLE
chore: update renovate config to align with release cadence

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,8 @@
     "group:monorepos",
     "schedule:weekends"
   ],
+  "timezone": "America/Chicago",
+  "schedule": ["0 0-4 1-7 2/2 1"],
   "enabledManagers": ["cargo", "github-actions", "npm", "nuget"],
   "commitMessagePrefix": "[deps]:",
   "commitMessageTopic": "{{depName}}",


### PR DESCRIPTION
## 📔 Objective

> Update renovate config to use the America/Chicago timezone and schedule PR creation on the **FIRST** Monday of each **EVEN** month before **5 AM**

