### PR TITLE
[PM-34635] add BWS_BASE_URL env var support for base_url option

### DIFF
--- a/plugins/lookup/lookup.py
+++ b/plugins/lookup/lookup.py
@@ -29,6 +29,8 @@ options:
   base_url:
     description: Base url to use. If provided, api_url and identity_url will be ignored.
     default: https://vault.bitwarden.com
+    env:
+      - name: BWS_BASE_URL
     required: False
     type: string
   api_url:


### PR DESCRIPTION
Users on non-default Bitwarden instances (e.g. EU server at vault.bitwarden.eu) had no way to configure base_url without hardcoding it in every lookup call. Adding env var support allows setting it once per session alongside BWS_ACCESS_TOKEN.

🎟️Tracking

  No related issue - discovered while configuring the plugin for a Bitwarden EU instance.

  🚧 Type of change

  - 🚀 New feature development

  📔 Objective

  Users on non-default Bitwarden instances (e.g. the EU server at vault.bitwarden.eu) had no way to configure base_url globally. The only option was to hardcode it in every single lookup call, which is impractical for large inventories.

  This PR adds BWS_BASE_URL environment variable support for the base_url option, consistent with the existing pattern of BWS_ACCESS_TOKEN for the access_token option.

  📋 Code changes

  - plugins/lookup/lookup.py: Added env: - name: BWS_BASE_URL to the base_url option in the plugin DOCUMENTATION. Ansible's lookup plugin framework automatically picks up the env var mapping with no additional code changes required.

  ⏰ Reminders before review

  - Contributor guidelines followed
  - All formatters and local linters executed and passed
  - ~~Written new unit and / or integration tests where applicable~~ - covered by existing tests; the env var handling is done entirely by Ansible's plugin framework
  - ~~Protected functional changes with optionality (feature flags)~~ - not applicable
  - ~~Used internationalization (i18n) for all UI strings~~ - not applicable
  - CI builds passed
  - ~~Communicated to DevOps any deployment requirements~~ - not applicable
  - Updated any necessary documentation or informed the documentation team
