### PR TITLE
fix: update renovate schedule minutes to wildcard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,7 @@
     "schedule:weekends"
   ],
   "timezone": "America/Chicago",
-  "schedule": ["0 0-4 1-7 2/2 1"],
+  "schedule": ["* 0-4 1-7 2/2 1"],
   "enabledManagers": ["cargo", "github-actions", "npm", "nuget"],
   "commitMessagePrefix": "[deps]:",
   "commitMessageTopic": "{{depName}}",


### PR DESCRIPTION
## 📔 Objective

> 0 in as the minutes value apparently does **not** work for cron formatting renovate schedule. Update to use the recommended wildcard value.