### PR TITLE
fix: remove step interval for renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,7 @@
     "schedule:weekends"
   ],
   "timezone": "America/Chicago",
-  "schedule": ["* 0-4 1-7 2/2 1"],
+  "schedule": ["* 6 1-7 2,4,6,8,10,12 1"],
   "enabledManagers": ["cargo", "github-actions", "npm", "nuget"],
   "commitMessagePrefix": "[deps]:",
   "commitMessageTopic": "{{depName}}",


### PR DESCRIPTION
## 📔 Objective

> Use strict cron syntax by removing step interval that is causing upstream issues for scheduling
